### PR TITLE
Overlay manager

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -9,6 +9,7 @@ sources = [
     "godotcord_activity_manager.cpp",
     "godotcord_lobby_manager.cpp",
     "godotcord_image_manager.cpp",
+    "godotcord_overlay_manager.cpp",
     "godotcord_relationship_manager.cpp",
     "godotcord_store_manager.cpp",
     "discord-files/achievement_manager.cpp",

--- a/godotcord_activity.h
+++ b/godotcord_activity.h
@@ -38,12 +38,12 @@ protected:
 		
 		ADD_GODOTCORD_PROPERTY(GodotcordActivity, application_id, Variant::INT);
 
-		BIND_ENUM_CONSTANT(ActivityRequestReply::NO);
-		BIND_ENUM_CONSTANT(ActivityRequestReply::YES);
-		BIND_ENUM_CONSTANT(ActivityRequestReply::IGNORE);
+		BIND_ENUM_CONSTANT(NO);
+		BIND_ENUM_CONSTANT(YES);
+		BIND_ENUM_CONSTANT(IGNORE);
 
-		BIND_ENUM_CONSTANT(ActivityActionType::JOIN);
-		BIND_ENUM_CONSTANT(ActivityActionType::SPECTATE);
+		BIND_ENUM_CONSTANT(JOIN);
+		BIND_ENUM_CONSTANT(SPECTATE);
 	}
 
 public:

--- a/godotcord_overlay_manager.cpp
+++ b/godotcord_overlay_manager.cpp
@@ -6,6 +6,50 @@ GodotcordOverlayManager *GodotcordOverlayManager::get_singleton() {
 	return GodotcordOverlayManager::singleton;
 }
 
+void GodotcordOverlayManager::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_enabled"), &GodotcordOverlayManager::is_enabled);
+	ClassDB::bind_method(D_METHOD("is_locked"), &GodotcordOverlayManager::is_locked);
+	ClassDB::bind_method(D_METHOD("set_locked", "locked"), &GodotcordOverlayManager::set_locked);
+	ClassDB::bind_method(D_METHOD("open_voice_settings"), &GodotcordOverlayManager::open_voice_settings);
+	ClassDB::bind_method(D_METHOD("open_activity_invite", "type"), &GodotcordOverlayManager::open_activity_invite);
+	ClassDB::bind_method(D_METHOD("open_guild_invite", "invite_code"), &GodotcordOverlayManager::open_guild_invite);
+}
+
+bool GodotcordOverlayManager::is_enabled() {
+	bool b;
+	Godotcord::get_singleton()->get_core()->OverlayManager().IsEnabled(&b);
+	return b;
+}
+
+bool GodotcordOverlayManager::is_locked() {
+	bool b;
+	Godotcord::get_singleton()->get_core()->OverlayManager().IsLocked(&b);
+	return b;
+}
+
+void GodotcordOverlayManager::set_locked(bool p_locked) {
+	Godotcord::get_singleton()->get_core()->OverlayManager().SetLocked(p_locked, [](discord::Result result) {
+		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occures trying set locked of the overlay");
+	});
+}
+
+void GodotcordOverlayManager::open_voice_settings() {
+	Godotcord::get_singleton()->get_core()->OverlayManager().OpenVoiceSettings([](discord::Result result) {
+		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occures trying to open the voice settings overlay");
+	});
+}
+
+void GodotcordOverlayManager::open_activity_invite(GodotcordActivity::ActivityActionType p_type) {
+	Godotcord::get_singleton()->get_core()->OverlayManager().OpenActivityInvite((discord::ActivityActionType)p_type, [](discord::Result result) {
+		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occured trying to open an activity invite dialog in the overlay");
+	});
+}
+
+void GodotcordOverlayManager::open_guild_invite(String p_invite_code) {
+	Godotcord::get_singleton()->get_core()->OverlayManager().OpenGuildInvite(p_invite_code.utf8(), [](discord::Result result) {
+		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occured trying to open the guild invite dialog in the overlay");
+	});
+}
 
 GodotcordOverlayManager::GodotcordOverlayManager() {
 	ERR_FAIL_COND_MSG(singleton != NULL, "Only one instance of GodotcordOverlayManager should exist");

--- a/godotcord_overlay_manager.cpp
+++ b/godotcord_overlay_manager.cpp
@@ -1,0 +1,14 @@
+#include "godotcord_overlay_manager.h"
+
+GodotcordOverlayManager *GodotcordOverlayManager::singleton = NULL;
+
+GodotcordOverlayManager *GodotcordOverlayManager::get_singleton() {
+	return GodotcordOverlayManager::singleton;
+}
+
+
+GodotcordOverlayManager::GodotcordOverlayManager() {
+	ERR_FAIL_COND_MSG(singleton != NULL, "Only one instance of GodotcordOverlayManager should exist");
+
+	singleton = this;
+}

--- a/godotcord_overlay_manager.h
+++ b/godotcord_overlay_manager.h
@@ -1,0 +1,18 @@
+#ifndef GODOTCORD_OVERLAY_MANAGER
+#define GODOTCORD_OVERLAY_MANAGER
+
+#include "core/object.h"
+
+class GodotcordOverlayManager : public Object {
+public:
+
+protected:
+	static void _bind_methods();
+public:
+	static GodotcordOverlayManager *singleton;
+	static GodotcordOverlayManager *get_singleton();
+
+	GodotcordOverlayManager();
+};
+
+#endif

--- a/godotcord_overlay_manager.h
+++ b/godotcord_overlay_manager.h
@@ -2,15 +2,23 @@
 #define GODOTCORD_OVERLAY_MANAGER
 
 #include "core/object.h"
+#include "godotcord.h"
 
 class GodotcordOverlayManager : public Object {
-public:
+	GDCLASS(GodotcordOverlayManager, Object);
 
 protected:
 	static void _bind_methods();
 public:
 	static GodotcordOverlayManager *singleton;
 	static GodotcordOverlayManager *get_singleton();
+
+	bool is_enabled();
+	bool is_locked();
+	void set_locked(bool p_locked);
+	void open_voice_settings();
+	void open_activity_invite(GodotcordActivity::ActivityActionType p_type);
+	void open_guild_invite(String p_invite_code);
 
 	GodotcordOverlayManager();
 };

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -11,6 +11,7 @@
 #include "godotcord_activity_manager.h"
 #include "godotcord_image_manager.h"
 #include "godotcord_lobby_manager.h"
+#include "godotcord_overlay_manager.h"
 #include "godotcord_relationship_manager.h"
 #include "godotcord_store_manager.h"
 
@@ -18,6 +19,7 @@ static Godotcord *GC_ptr = NULL;
 static GodotcordActivityManager *GC_ACT_ptr = NULL;
 static GodotcordImageManager *GC_IMG_ptr = NULL;
 static GodotcordLobbyManager *GC_LOBBY_ptr = NULL;
+static GodotcordOverlayManager *GC_OVRL_ptr = NULL;
 static GodotcordRelationshipManager *GC_RELSHIP_ptr = NULL;
 static GodotcordStoreManager *GC_STORE_ptr = NULL;
 
@@ -45,6 +47,9 @@ void register_godotcord_types() {
 	GC_LOBBY_ptr = memnew(GodotcordLobbyManager);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GodotcordLobbyManager", GodotcordLobbyManager::get_singleton()));
 
+	GC_OVRL_ptr = memnew(GodotcordOverlayManager);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GodotcordOverlayManager", GodotcordOverlayManager::get_singleton()));
+
 	GC_RELSHIP_ptr = memnew(GodotcordRelationshipManager);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GodotcordRelationshipManager", GodotcordRelationshipManager::get_singleton()));
 	
@@ -57,6 +62,7 @@ void unregister_godotcord_types() {
 	memdelete(GC_ACT_ptr);
 	memdelete(GC_IMG_ptr);
 	memdelete(GC_LOBBY_ptr);
+	memdelete(GC_OVRL_ptr);
 	memdelete(GC_RELSHIP_ptr);
 	memdelete(GC_STORE_ptr);
 }


### PR DESCRIPTION
Add following features:
- get overlay state
- set whether overlay is locked
- open activity invite in overlay or discord client (an activity has to be set for this to work)
- open guild invite in overlay or discord client
- open voice settings in overlay or discord client

