### PR TITLE
Detect OS when platform=server so it links correctly

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -1,5 +1,6 @@
 # SCsub
 
+import platform as p
 Import('env')
 
 sources = [
@@ -29,28 +30,43 @@ sources = [
     "discord-files/user_manager.cpp",
     "discord-files/voice_manager.cpp"
 ]
-    
 
-if env["platform"] == "windows":
 
-    env.add_source_files(env.modules_sources, sources)
-    env.Append(LIBPATH=['#modules/godotcord/libpath'])
+def detect_platform_for_server(platform_string):
+    switcher = {
+        'Linux': 'x11',
+        'Darwin': 'osx',
+        'Windows': 'windows'
+    }
+    return switcher.get(platform_string, "Invalid platform")
 
-    if env["bits"] == "64":
-        env.Append(LINKFLAGS=['discord_game_sdk.dll.lib'])
-    elif env["bits"] == "32":
-        env.Append(LINKFLAGS=['discord_game_sdk.32.dll.lib'])
-elif(env["platform"] == "x11"):
-    if env["bits"] == "64":
+
+platform = env["platform"]
+
+def set_linker_vars():
+    if platform == "windows":
         env.add_source_files(env.modules_sources, sources)
         env.Append(LIBPATH=['#modules/godotcord/libpath'])
-
-        env.Append(RPATH=[Literal("\$$ORIGIN:.")])
-
+        if env["bits"] == "64":
+            env.Append(LINKFLAGS=['discord_game_sdk.dll.lib'])
+        elif env["bits"] == "32":
+            env.Append(LINKFLAGS=['discord_game_sdk.32.dll.lib'])
+    elif(platform == "x11"):
+        if env["bits"] == "64":
+            env.add_source_files(env.modules_sources, sources)
+            env.Append(LIBPATH=['#modules/godotcord/libpath'])
+            env.Append(RPATH=[Literal("\$$ORIGIN:.")])
+            env.Append(LIBS=['discord_game_sdk'])
+    elif(platform == "osx"):
+        env.add_source_files(env.modules_sources, sources)
+        env.Append(LIBPATH=['#modules/godotcord/libpath'])
         env.Append(LIBS=['discord_game_sdk'])
-elif(env["platform"] == "osx"):
-    env.add_source_files(env.modules_sources, sources)
-    env.Append(LIBPATH=['#modules/godotcord/libpath'])
+        env.Append(RPATH=["."])
 
-    env.Append(LIBS=['discord_game_sdk'])
-    env.Append(RPATH=["."])
+
+if env["platform"] != "server":
+    set_linker_vars()
+else:
+    print(p.system())
+    platform = detect_platform_for_server(p.system())
+    set_linker_vars()


### PR DESCRIPTION
Previously, compiling for Servers would fail because the godotcord SCsub wasn't supporting the `server` platform.
I added OS detection when `platform == "server"` to fix this.﻿
