### PR TITLE
Windows setup.bat adds '#include <cstdint>' to types.h

### DIFF
--- a/finish_setup.ps1
+++ b/finish_setup.ps1
@@ -1,0 +1,3 @@
+Write-Output "Adding #include <cstdint> to types.h"
+(Get-Content .\discord-files\types.h).replace("#pragma once", "#pragma once`r`n#include <cstdint>") | Set-Content .\discord-files\types.h
+Write-Output "Done! Setup complete."

--- a/setup.bat
+++ b/setup.bat
@@ -14,3 +14,5 @@ copy dgsdk\lib\x86\discord_game_sdk.dll libpath\discord_game_sdk.32.dll
 copy dgsdk\lib\x86\discord_game_sdk.dll.lib libpath\discord_game_sdk.32.dll.lib
 del discord_game_sdk.zip
 RMDIR /S /Q dgsdk
+
+PowerShell.exe -ExecutionPolicy Bypass -Command "& './finish_setup.ps1'"


### PR DESCRIPTION
I added a script (`finish_setup.ps1`) that is ran at the end of setup.bat so it can bypass execute policies.
The powershell script adds `#include <cstdint>` to line 2 of types.h to fix #20.