### PR TITLE
Add separate compile with target=debug to help track down bugs

### DIFF
--- a/.github/workflows/build-download.yaml
+++ b/.github/workflows/build-download.yaml
@@ -46,7 +46,7 @@ jobs:
 
         - run: ${{matrix.DOWNLOAD}}
 
-        - name: Compile
+        - name: Compile with target=release_debug
           run: scons bits=64 target=release_debug -j2
 
         - name: Modify binary after compilation
@@ -57,3 +57,15 @@ jobs:
           with:
             name: godotcord-binary-${{matrix.os}}
             path: bin/godot.${{matrix.PLATFORM}}.opt.tools.${{matrix.EXTENSION}}
+
+        - name: Compile with target=debug
+          run: scons bits=64 target=debug -j2
+
+        - name: Modify binary after compilation
+          run: ${{matrix.AFTER_COMP_CMD}}
+
+        - name: Upload binary
+          uses: actions/upload-artifact@v2
+          with:
+            name: godotcord-binary-${{matrix.os}}-debug
+            path: bin/godot.${{matrix.PLATFORM}}.debug.opt.tools.${{matrix.EXTENSION}}

--- a/.github/workflows/build-download.yaml
+++ b/.github/workflows/build-download.yaml
@@ -68,4 +68,4 @@ jobs:
           uses: actions/upload-artifact@v2
           with:
             name: godotcord-binary-${{matrix.os}}-debug
-            path: bin/godot.${{matrix.PLATFORM}}.debug.tools.${{matrix.EXTENSION}}
+            path: bin/godot.${{matrix.PLATFORM}}.tools.${{matrix.EXTENSION}}

--- a/.github/workflows/build-download.yaml
+++ b/.github/workflows/build-download.yaml
@@ -68,4 +68,4 @@ jobs:
           uses: actions/upload-artifact@v2
           with:
             name: godotcord-binary-${{matrix.os}}-debug
-            path: bin/godot.${{matrix.PLATFORM}}.debug.opt.tools.${{matrix.EXTENSION}}
+            path: bin/godot.${{matrix.PLATFORM}}.debug.tools.${{matrix.EXTENSION}}


### PR DESCRIPTION
Allows people downloading from build artifacts to use target=debug to get better errors while godotcord isn't stable.