### PR TITLE
Change CreateFlags to enum

### DIFF
--- a/godotcord.cpp
+++ b/godotcord.cpp
@@ -33,9 +33,13 @@ void Godotcord::_bind_methods() {
     ClassDB::bind_method(D_METHOD("init", "client_id", "createFlags"), &Godotcord::init);
 	ClassDB::bind_method(D_METHOD("init_debug", "client_id", "instance_id", "createFlags"), &Godotcord::init_debug);
 	ClassDB::bind_method(D_METHOD("run_callbacks"), &Godotcord::run_callbacks);
+
+	BIND_ENUM_CONSTANT(DEFAULT);
+	BIND_ENUM_CONSTANT(NO_REQUIRE_DISCORD);
+
 }
 	
-Error Godotcord::init(discord::ClientId clientId, int createFlags = DiscordCreateFlags_Default) {
+Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = CreateFlags::DEFAULT) {
 	discord::Result result = discord::Core::Create(clientId, createFlags, &_core);
 
 	ERR_FAIL_COND_V(result != discord::Result::Ok, ERR_CANT_CONNECT);
@@ -45,7 +49,7 @@ Error Godotcord::init(discord::ClientId clientId, int createFlags = DiscordCreat
 	return OK;
 }
 
-void Godotcord::init_debug(discord::ClientId clientId, String id, int createFlags = DiscordCreateFlags_Default) {
+void Godotcord::init_debug(discord::ClientId clientId, String id, CreateFlags createFlags = CreateFlags::DEFAULT) {
 #ifdef _WIN32
 	_putenv_s("DISCORD_INSTANCE_ID", id.utf8());
 #else

--- a/godotcord.cpp
+++ b/godotcord.cpp
@@ -39,7 +39,7 @@ void Godotcord::_bind_methods() {
 
 }
 	
-Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = CreateFlags::DEFAULT) {
+Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = CreateFlags::Create_DEFAULT) {
 	discord::Result result = discord::Core::Create(clientId, createFlags, &_core);
 
 	ERR_FAIL_COND_V(result != discord::Result::Ok, ERR_CANT_CONNECT);
@@ -49,7 +49,7 @@ Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = Crea
 	return OK;
 }
 
-void Godotcord::init_debug(discord::ClientId clientId, String id, CreateFlags createFlags = CreateFlags::DEFAULT) {
+void Godotcord::init_debug(discord::ClientId clientId, String id, CreateFlags createFlags = CreateFlags::Create_DEFAULT) {
 #ifdef _WIN32
 	_putenv_s("DISCORD_INSTANCE_ID", id.utf8());
 #else

--- a/godotcord.cpp
+++ b/godotcord.cpp
@@ -34,8 +34,8 @@ void Godotcord::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("init_debug", "client_id", "instance_id", "createFlags"), &Godotcord::init_debug);
 	ClassDB::bind_method(D_METHOD("run_callbacks"), &Godotcord::run_callbacks);
 
-	BIND_ENUM_CONSTANT(DEFAULT);
-	BIND_ENUM_CONSTANT(NO_REQUIRE_DISCORD);
+	BIND_ENUM_CONSTANT(Create_DEFAULT);
+	BIND_ENUM_CONSTANT(Create_NO_REQUIRE_DISCORD);
 
 }
 	

--- a/godotcord.cpp
+++ b/godotcord.cpp
@@ -34,12 +34,12 @@ void Godotcord::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("init_debug", "client_id", "instance_id", "createFlags"), &Godotcord::init_debug);
 	ClassDB::bind_method(D_METHOD("run_callbacks"), &Godotcord::run_callbacks);
 
-	BIND_ENUM_CONSTANT(Create_DEFAULT);
-	BIND_ENUM_CONSTANT(Create_NO_REQUIRE_DISCORD);
+	BIND_ENUM_CONSTANT(CreateFlags_DEFAULT);
+	BIND_ENUM_CONSTANT(CreateFlags_NO_REQUIRE_DISCORD);
 
 }
 	
-Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = CreateFlags::Create_DEFAULT) {
+Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = CreateFlags::CreateFlags_DEFAULT) {
 	discord::Result result = discord::Core::Create(clientId, createFlags, &_core);
 
 	ERR_FAIL_COND_V(result != discord::Result::Ok, ERR_CANT_CONNECT);
@@ -49,7 +49,7 @@ Error Godotcord::init(discord::ClientId clientId, CreateFlags createFlags = Crea
 	return OK;
 }
 
-void Godotcord::init_debug(discord::ClientId clientId, String id, CreateFlags createFlags = CreateFlags::Create_DEFAULT) {
+void Godotcord::init_debug(discord::ClientId clientId, String id, CreateFlags createFlags = CreateFlags::CreateFlags_DEFAULT) {
 #ifdef _WIN32
 	_putenv_s("DISCORD_INSTANCE_ID", id.utf8());
 #else

--- a/godotcord.h
+++ b/godotcord.h
@@ -28,8 +28,13 @@ public:
 	static Godotcord *singleton;
 	static Godotcord *get_singleton();
 
-    Error init(discord::ClientId clientId, int createFlags);
-	void init_debug(discord::ClientId clientId, String id, int createFlags);
+	enum CreateFlags {
+		DEFAULT = 0,
+		NO_REQUIRE_DISCORD = 1,
+	};
+
+    Error init(discord::ClientId clientId, CreateFlags createFlags);
+	void init_debug(discord::ClientId clientId, String id, CreateFlags createFlags);
 
 	void run_callbacks();
 
@@ -46,5 +51,7 @@ public:
     Godotcord();
 	~Godotcord();
 };
+
+VARIANT_ENUM_CAST(Godotcord::CreateFlags);
 
 #endif

--- a/godotcord.h
+++ b/godotcord.h
@@ -29,8 +29,8 @@ public:
 	static Godotcord *get_singleton();
 
 	enum CreateFlags {
-		Create_DEFAULT = 0,
-		Create_NO_REQUIRE_DISCORD = 1,
+		CreateFlags_DEFAULT = 0,
+		CreateFlags_NO_REQUIRE_DISCORD = 1,
 	};
 
     Error init(discord::ClientId clientId, CreateFlags createFlags);

--- a/godotcord.h
+++ b/godotcord.h
@@ -29,8 +29,8 @@ public:
 	static Godotcord *get_singleton();
 
 	enum CreateFlags {
-		DEFAULT = 0,
-		NO_REQUIRE_DISCORD = 1,
+		Create_DEFAULT = 0,
+		Create_NO_REQUIRE_DISCORD = 1,
 	};
 
     Error init(discord::ClientId clientId, CreateFlags createFlags);


### PR DESCRIPTION
New syntax for `Godotcord.init` and `init_debug`:
`Godotcord.init(CLIENT_ID, Godotcord.CreateFlags_Default);`

`enum  CreateFlags {
    CreateFlags_DEFAULT=0,
    CreateFlags_NO_REQUIRE_DISCORD=1,
}`