### PR TITLE
Fix download workflows

### DIFF
--- a/.github/workflows/build-download.yaml
+++ b/.github/workflows/build-download.yaml
@@ -17,7 +17,7 @@ jobs:
                   DOWNLOAD: brew install scons
                   PLATFORM: osx
                   EXTENSION: 64
-                  AFTER_COMP_CMD: install_name_tool -add_rpath @executable_path bin/godot.osx.opt.tools.64
+                  AFTER_COMP_CMD: install_name_tool -add_rpath @executable_path
                 - os: ubuntu-latest
                   SETUP: ./setup.sh
                   DOWNLOAD: sudo apt update && sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
@@ -50,7 +50,7 @@ jobs:
           run: scons bits=64 target=release_debug -j2
 
         - name: Modify binary after compilation
-          run: ${{matrix.AFTER_COMP_CMD}}
+          run: ${{matrix.AFTER_COMP_CMD}} bin/godot.${{matrix.PLATFORM}}.opt.tools.${{matrix.EXTENSION}}
 
         - name: Upload binary
           uses: actions/upload-artifact@v2
@@ -62,7 +62,7 @@ jobs:
           run: scons bits=64 target=debug -j2
 
         - name: Modify binary after compilation
-          run: ${{matrix.AFTER_COMP_CMD}}
+          run: ${{matrix.AFTER_COMP_CMD}} bin/godot.${{matrix.PLATFORM}}.tools.${{matrix.EXTENSION}}
 
         - name: Upload binary
           uses: actions/upload-artifact@v2


### PR DESCRIPTION
Adding the debug builds broke the workflow for mac os. This should fix it.