### PR TITLE
Move FuncRefs to signals - Fixes #55

### DIFF
--- a/godotcord_achievement_manager.cpp
+++ b/godotcord_achievement_manager.cpp
@@ -9,7 +9,7 @@ GodotcordAchievementManager* GodotcordAchievementManager::get_singleton() {
 
 void GodotcordAchievementManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_user_achievement", "achievement_id", "percent_complete"), &GodotcordAchievementManager::set_user_achievement);
-	ClassDB::bind_method(D_METHOD("fetch_user_achievements", "object", "function_name"), &GodotcordAchievementManager::fetch_user_achievements);
+	ClassDB::bind_method(D_METHOD("fetch_user_achievements"), &GodotcordAchievementManager::fetch_user_achievements);
 	ClassDB::bind_method(D_METHOD("get_user_achievements"), &GodotcordAchievementManager::get_user_achievements);
 
 	ADD_SIGNAL(MethodInfo("fetch_user_achievements"));

--- a/godotcord_achievement_manager.cpp
+++ b/godotcord_achievement_manager.cpp
@@ -1,8 +1,6 @@
 #include "godotcord_achievement_manager.h"
 #include "godotcord.h"
 
-#include "core/func_ref.h"
-
 GodotcordAchievementManager *GodotcordAchievementManager::singleton = NULL;
 
 GodotcordAchievementManager* GodotcordAchievementManager::get_singleton() {
@@ -13,6 +11,8 @@ void GodotcordAchievementManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_user_achievement", "achievement_id", "percent_complete"), &GodotcordAchievementManager::set_user_achievement);
 	ClassDB::bind_method(D_METHOD("fetch_user_achievements", "object", "function_name"), &GodotcordAchievementManager::fetch_user_achievements);
 	ClassDB::bind_method(D_METHOD("get_user_achievements"), &GodotcordAchievementManager::get_user_achievements);
+
+	ADD_SIGNAL(MethodInfo("fetch_user_achievements"));
 }
 
 void GodotcordAchievementManager::set_user_achievement(int64_t p_achievement_id, int8_t p_percent) {
@@ -21,18 +21,10 @@ void GodotcordAchievementManager::set_user_achievement(int64_t p_achievement_id,
 	});
 }
 
-void GodotcordAchievementManager::fetch_user_achievements(Object *p_object, StringName p_funcname) {
-	ERR_FAIL_NULL(p_object);
-
-	Godotcord::get_singleton()->get_core()->AchievementManager().FetchUserAchievements([this, p_object, p_funcname](discord::Result result) {
+void GodotcordAchievementManager::fetch_user_achievements() {
+	Godotcord::get_singleton()->get_core()->AchievementManager().FetchUserAchievements([this](discord::Result result) {
 		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occured while fetching the local users achievements");
-		FuncRef callback;
-		callback.set_instance(p_object);
-		callback.set_function(p_funcname);
-
-		Array r;
-
-		callback.call_funcv(r);
+		emit_signal("fetch_user_achievements");
 	});
 }
 

--- a/godotcord_achievement_manager.h
+++ b/godotcord_achievement_manager.h
@@ -14,7 +14,7 @@ public:
 	static GodotcordAchievementManager *get_singleton();
 
 	void set_user_achievement(int64_t p_achievement_id, int8_t p_percent);
-	void fetch_user_achievements(Object *p_object, StringName p_funcname);
+	void fetch_user_achievements();
 	Array get_user_achievements();
 
 

--- a/godotcord_image_manager.cpp
+++ b/godotcord_image_manager.cpp
@@ -1,6 +1,5 @@
 #include "godotcord_image_manager.h"
 #include "godotcord.h"
-#include "core/func_ref.h"
 
 GodotcordImageManager *GodotcordImageManager::singleton = NULL;
 
@@ -10,21 +9,18 @@ GodotcordImageManager *GodotcordImageManager::get_singleton() {
 
 void GodotcordImageManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_profile_picture", "user_id", "size", "object", "function_name"), &GodotcordImageManager::get_profile_picture);
+
+	ADD_SIGNAL(MethodInfo("profile_picture_callback", PropertyInfo(Variant::INT, "user_id"), PropertyInfo(Variant::POOL_BYTE_ARRAY, "image_data")));
 }
 
-void GodotcordImageManager::get_profile_picture(int64_t p_user_id, int p_size, Object* p_object, StringName p_funcname) {
-	ERR_FAIL_NULL(p_object);
-	FuncRef callback;
-	callback.set_instance(p_object);
-	callback.set_function(p_funcname);
-
+void GodotcordImageManager::get_profile_picture(int64_t p_user_id, int p_size) {
 	discord::ImageHandle handle;
 	handle.SetId(p_user_id);
 	handle.SetSize(p_size);
 	handle.SetType(discord::ImageType::User);
 	Godotcord::get_singleton()->get_core()->ImageManager()
 			.Fetch(
-					handle, false, [this, p_user_id, &callback](discord::Result result, discord::ImageHandle returned_handle) {
+					handle, false, [this, p_user_id](discord::Result result, discord::ImageHandle returned_handle) {
 						ERR_FAIL_COND_MSG(result != discord::Result::Ok, "Something went wrong while requesting the profile picture");
 
 						discord::ImageDimensions dim;
@@ -38,10 +34,7 @@ void GodotcordImageManager::get_profile_picture(int64_t p_user_id, int p_size, O
 
 						write.release();
 
-						Array a;
-						a.push_back(p_user_id);
-						a.push_back(data);
-						callback.call_funcv(a);
+						emit_signal("profile_picture_callback", p_user_id, data);
 					});
 }
 

--- a/godotcord_image_manager.cpp
+++ b/godotcord_image_manager.cpp
@@ -8,7 +8,7 @@ GodotcordImageManager *GodotcordImageManager::get_singleton() {
 }
 
 void GodotcordImageManager::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_profile_picture", "user_id", "size", "object", "function_name"), &GodotcordImageManager::get_profile_picture);
+	ClassDB::bind_method(D_METHOD("get_profile_picture", "user_id", "size"), &GodotcordImageManager::get_profile_picture);
 
 	ADD_SIGNAL(MethodInfo("profile_picture_callback", PropertyInfo(Variant::INT, "user_id"), PropertyInfo(Variant::POOL_BYTE_ARRAY, "image_data")));
 }

--- a/godotcord_image_manager.h
+++ b/godotcord_image_manager.h
@@ -13,7 +13,7 @@ public:
 	static GodotcordImageManager *singleton;
 	static GodotcordImageManager *get_singleton();
 
-	void get_profile_picture(int64_t p_user_id, int p_size, Object *p_object, StringName p_funcname);
+	void get_profile_picture(int64_t p_user_id, int p_size);
 
 	GodotcordImageManager();
 	~GodotcordImageManager();

--- a/godotcord_lobby_manager.cpp
+++ b/godotcord_lobby_manager.cpp
@@ -1,6 +1,5 @@
 #include "godotcord_lobby_manager.h"
 #include "godotcord.h"
-#include "core/func_ref.h"
 
 GodotcordLobbyManager *GodotcordLobbyManager::singleton = NULL;
 
@@ -12,6 +11,8 @@ void GodotcordLobbyManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_lobby_metadata", "lobby_id", "key", "value"), &GodotcordLobbyManager::set_lobby_metadata);
 	ClassDB::bind_method(D_METHOD("get_lobby_metadata", "lobby_id", "key"), &GodotcordLobbyManager::get_lobby_metadata);
 	ClassDB::bind_method(D_METHOD("search_lobbies", "parameters, limit", "object", "function_name"), &GodotcordLobbyManager::search_lobbies);
+
+	ADD_SIGNAL(MethodInfo("search_lobbies_callback", PropertyInfo(Variant::OBJECT, "lobbies")));
 
 	BIND_ENUM_CONSTANT(LOCAL);
 	BIND_ENUM_CONSTANT(DEFAULT);
@@ -50,13 +51,8 @@ String GodotcordLobbyManager::get_lobby_metadata(int64_t p_lobby_id, String p_ke
 	return String(value);
 }
 
-void GodotcordLobbyManager::search_lobbies(Variant p_params, int p_limit, Object *p_object, StringName p_funcname) {
+void GodotcordLobbyManager::search_lobbies(Variant p_params, int p_limit) {
 	ERR_FAIL_COND_MSG(!p_params.is_array(), "The search_parameters has to be an array");
-
-	ERR_FAIL_NULL(p_object);
-	FuncRef callback;
-	callback.set_instance(p_object);
-	callback.set_function(p_funcname);
 
 	Array params = p_params;
 	discord::LobbySearchQuery query;
@@ -142,7 +138,7 @@ void GodotcordLobbyManager::search_lobbies(Variant p_params, int p_limit, Object
 		}
 	}
 
-	Godotcord::get_singleton()->get_core()->LobbyManager().Search(query, [this, &callback](discord::Result result) {
+	Godotcord::get_singleton()->get_core()->LobbyManager().Search(query, [this](discord::Result result) {
 		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "Something went wrong while filtering the lobbies");
 
 		Vector<Variant> vec;
@@ -165,9 +161,7 @@ void GodotcordLobbyManager::search_lobbies(Variant p_params, int p_limit, Object
 			vec.push_back(GodotcordLobby::get_dictionary(&gd_lobby));
 		}
 
-		Array a;
-		a.push_back(vec);
-		callback.call_funcv(a);
+		emit_signal("search_lobbies_callback", vec);
 	});
 }
 

--- a/godotcord_lobby_manager.cpp
+++ b/godotcord_lobby_manager.cpp
@@ -10,7 +10,7 @@ GodotcordLobbyManager *GodotcordLobbyManager::get_singleton() {
 void GodotcordLobbyManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_lobby_metadata", "lobby_id", "key", "value"), &GodotcordLobbyManager::set_lobby_metadata);
 	ClassDB::bind_method(D_METHOD("get_lobby_metadata", "lobby_id", "key"), &GodotcordLobbyManager::get_lobby_metadata);
-	ClassDB::bind_method(D_METHOD("search_lobbies", "parameters, limit", "object", "function_name"), &GodotcordLobbyManager::search_lobbies);
+	ClassDB::bind_method(D_METHOD("search_lobbies", "parameters, limit"), &GodotcordLobbyManager::search_lobbies);
 
 	ADD_SIGNAL(MethodInfo("search_lobbies_callback", PropertyInfo(Variant::OBJECT, "lobbies")));
 

--- a/godotcord_lobby_manager.h
+++ b/godotcord_lobby_manager.h
@@ -38,7 +38,7 @@ public:
 	void set_lobby_metadata(int64_t lobby_id, String key, String value);
 	String get_lobby_metadata(int64_t lobby_id, String key);
 
-	void search_lobbies(Variant params, int limit, Object* p_object, StringName p_funcname);
+	void search_lobbies(Variant params, int limit);
 
 	GodotcordLobbyManager();
 	~GodotcordLobbyManager();

--- a/godotcord_store_manager.cpp
+++ b/godotcord_store_manager.cpp
@@ -1,6 +1,5 @@
 #include "godotcord_store_manager.h"
 #include "godotcord.h"
-#include "core/func_ref.h"
 
 GodotcordStoreManager *GodotcordStoreManager::singleton = NULL;
 
@@ -16,6 +15,9 @@ void GodotcordStoreManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_sku_entitlement", "sku_id"), &GodotcordStoreManager::has_sku_entitlement);
 	ClassDB::bind_method(D_METHOD("start_purchase", "sku_id"), &GodotcordStoreManager::start_purchase);
 
+	ADD_SIGNAL(MethodInfo("fetch_skus_callback", PropertyInfo(Variant::ARRAY, "skus")));
+	ADD_SIGNAL(MethodInfo("fetch_entitlements_callback", PropertyInfo(Variant::ARRAY, "entitlements")));
+
 	BIND_ENUM_CONSTANT(APP);
 	BIND_ENUM_CONSTANT(DLC);
 	BIND_ENUM_CONSTANT(CONSUMABLE);
@@ -30,21 +32,11 @@ void GodotcordStoreManager::_bind_methods() {
 	BIND_ENUM_CONSTANT(PREMIUM_PURCHASE);
 }
 
-void GodotcordStoreManager::fetch_skus(Object* p_object, StringName p_funcname) {
-	ERR_FAIL_NULL(p_object);
-
-	FuncRef callback;
-	callback.set_instance(p_object);
-	callback.set_function(p_funcname);
-
-	Godotcord::get_singleton()->get_core()->StoreManager().FetchSkus([this, &callback](discord::Result result) {
+void GodotcordStoreManager::fetch_skus() {
+	Godotcord::get_singleton()->get_core()->StoreManager().FetchSkus([this](discord::Result result) {
 		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occured while fetching user entitlements");
 
-		Array a;
-
-		a.push_back(this->get_skus());
-
-		callback.call_funcv(a);
+		emit_signal("fetch_skus_callback", this->get_skus());
 	});
 }
 
@@ -76,21 +68,11 @@ Array GodotcordStoreManager::get_skus() {
 	return ret;
 }
 
-void GodotcordStoreManager::fetch_entitlements(Object* p_object, StringName p_funcname) {
-	ERR_FAIL_NULL(p_object);
-
-	FuncRef callback;
-	callback.set_instance(p_object);
-	callback.set_function(p_funcname);
-
-	Godotcord::get_singleton()->get_core()->StoreManager().FetchEntitlements([this, &callback](discord::Result result) {
+void GodotcordStoreManager::fetch_entitlements() {
+	Godotcord::get_singleton()->get_core()->StoreManager().FetchEntitlements([this](discord::Result result) {
 		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occured while fetching user entitlements");
 
-		Array a;
-
-		a.push_back(this->get_skus());
-
-		callback.call_funcv(a);
+		emit_signal("fetch_entitlements_callback", this->get_entitlements());
 	});
 }
 

--- a/godotcord_store_manager.cpp
+++ b/godotcord_store_manager.cpp
@@ -8,9 +8,9 @@ GodotcordStoreManager *GodotcordStoreManager::get_singleton() {
 }
 
 void GodotcordStoreManager::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("fetch_skus", "object", "funcname"), &GodotcordStoreManager::fetch_skus);
+	ClassDB::bind_method(D_METHOD("fetch_skus"), &GodotcordStoreManager::fetch_skus);
 	ClassDB::bind_method(D_METHOD("get_skus"), &GodotcordStoreManager::get_skus);
-	ClassDB::bind_method(D_METHOD("fetch_entitlements", "object", "funcname"), &GodotcordStoreManager::fetch_entitlements);
+	ClassDB::bind_method(D_METHOD("fetch_entitlements"), &GodotcordStoreManager::fetch_entitlements);
 	ClassDB::bind_method(D_METHOD("get_entitlements"), &GodotcordStoreManager::get_entitlements);
 	ClassDB::bind_method(D_METHOD("has_sku_entitlement", "sku_id"), &GodotcordStoreManager::has_sku_entitlement);
 	ClassDB::bind_method(D_METHOD("start_purchase", "sku_id"), &GodotcordStoreManager::start_purchase);

--- a/godotcord_store_manager.h
+++ b/godotcord_store_manager.h
@@ -31,9 +31,9 @@ public:
 	static GodotcordStoreManager *singleton;
     static GodotcordStoreManager *get_singleton();
 
-	void fetch_skus(Object *p_object, StringName p_funcname);
+	void fetch_skus();
 	Array get_skus();
-	void fetch_entitlements(Object *p_objects, StringName p_funcname);
+	void fetch_entitlements();
 	Array get_entitlements();
 	bool has_sku_entitlement(int64_t p_sku_id);
 	void start_purchase(int64_t p_sku_id);

--- a/godotcord_user_manager.cpp
+++ b/godotcord_user_manager.cpp
@@ -1,6 +1,5 @@
 #include "godotcord_user_manager.h"
 #include "godotcord.h"
-#include "core/func_ref.h"
 
 GodotcordUserManager *GodotcordUserManager::singleton = NULL;
 
@@ -14,6 +13,8 @@ void GodotcordUserManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_user_premium_type"), &GodotcordUserManager::get_current_user_premium_type);
 	ClassDB::bind_method(D_METHOD("has_current_user_flag", "user_flag"), &GodotcordUserManager::has_current_user_flag);
 
+	ADD_SIGNAL(MethodInfo("get_user_callback", PropertyInfo(Variant::DICTIONARY, "user")));
+
 	BIND_ENUM_CONSTANT(PARTNER);
 	BIND_ENUM_CONSTANT(HYPE_SQUAD_EVENTS);
 	BIND_ENUM_CONSTANT(HYPE_SQUAD_HOUSE_1);
@@ -26,16 +27,9 @@ void GodotcordUserManager::_bind_methods() {
 	BIND_ENUM_CONSTANT(TIER_2);
 }
 
-void GodotcordUserManager::get_user(int64_t p_user_id, Object *p_object, StringName p_funcname) {
-	ERR_FAIL_NULL(p_object);
-
-	//declaring callback outside the lambda didn't work in this case. The object was empty in the lambda function. I don't why.
-	Godotcord::get_singleton()->get_core()->UserManager().GetUser(p_user_id, [p_object, p_funcname](discord::Result result, discord::User user) {
+void GodotcordUserManager::get_user(int64_t p_user_id) {
+	Godotcord::get_singleton()->get_core()->UserManager().GetUser(p_user_id, [this](discord::Result result, discord::User user) {
 		ERR_FAIL_COND_MSG(result != discord::Result::Ok, "An error occured while trying to fetch the user");
-		FuncRef callback;
-		callback.set_instance(p_object);
-		callback.set_function(p_funcname);
-
 		Dictionary d;
 
 		d["id"] = user.GetId();
@@ -44,9 +38,7 @@ void GodotcordUserManager::get_user(int64_t p_user_id, Object *p_object, StringN
 		d["avatar"] = user.GetAvatar();
 		d["bot"] = user.GetBot();
 
-		Array a;
-		a.push_back(d);
-		callback.call_funcv(a);
+		emit_signal("get_user_callback", d);
 	});
 }
 

--- a/godotcord_user_manager.cpp
+++ b/godotcord_user_manager.cpp
@@ -8,7 +8,7 @@ GodotcordUserManager* GodotcordUserManager::get_singleton() {
 }
 
 void GodotcordUserManager::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_user", "user_id", "object", "funcname"), &GodotcordUserManager::get_user);
+	ClassDB::bind_method(D_METHOD("get_user", "user_id"), &GodotcordUserManager::get_user);
 	ClassDB::bind_method(D_METHOD("get_current_user"), &GodotcordUserManager::get_current_user);
 	ClassDB::bind_method(D_METHOD("get_current_user_premium_type"), &GodotcordUserManager::get_current_user_premium_type);
 	ClassDB::bind_method(D_METHOD("has_current_user_flag", "user_flag"), &GodotcordUserManager::has_current_user_flag);

--- a/godotcord_user_manager.h
+++ b/godotcord_user_manager.h
@@ -29,7 +29,7 @@ public:
 	static GodotcordUserManager *singleton;
 	static GodotcordUserManager *get_singleton();
 
-	void get_user(int64_t p_user_id, Object *p_object, StringName p_funcname);
+	void get_user(int64_t p_user_id);
 	Dictionary get_current_user();
 	PremiumType get_current_user_premium_type();
 	bool has_current_user_flag(UserFlag p_flag);


### PR DESCRIPTION
Replaced most FuncRefs with signals. I could not replace the FuncRef in the relationship manager, because the return value for the function is required and signals don't provide return values (to my knowledge).