### PR TITLE
Fix typo in network peer and "local_user_updated" signal

### DIFF
--- a/godotcord_network_peer.cpp
+++ b/godotcord_network_peer.cpp
@@ -536,7 +536,7 @@ void NetworkedMultiplayerGodotcord::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("join_lobby", "id", "secret"), &NetworkedMultiplayerGodotcord::join_lobby);
 	ClassDB::bind_method(D_METHOD("join_server_activity", "secret"), &NetworkedMultiplayerGodotcord::join_lobby_activity);
 	ClassDB::bind_method(D_METHOD("close_connection"), &NetworkedMultiplayerGodotcord::close_connection);
-	ClassDB::bind_method(D_METHOD("disconnect_perr", "id"), &NetworkedMultiplayerGodotcord::disconnect_peer);
+	ClassDB::bind_method(D_METHOD("disconnect_peer", "id"), &NetworkedMultiplayerGodotcord::disconnect_peer);
 
 	ClassDB::bind_method(D_METHOD("get_lobby_id"), &NetworkedMultiplayerGodotcord::get_lobby_id);
 	ClassDB::bind_method(D_METHOD("get_lobby_secret"), &NetworkedMultiplayerGodotcord::get_lobby_secret);

--- a/godotcord_user_manager.cpp
+++ b/godotcord_user_manager.cpp
@@ -14,6 +14,7 @@ void GodotcordUserManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_current_user_flag", "user_flag"), &GodotcordUserManager::has_current_user_flag);
 
 	ADD_SIGNAL(MethodInfo("get_user_callback", PropertyInfo(Variant::DICTIONARY, "user")));
+	ADD_SIGNAL(MethodInfo("local_user_updated"));
 
 	BIND_ENUM_CONSTANT(PARTNER);
 	BIND_ENUM_CONSTANT(HYPE_SQUAD_EVENTS);
@@ -77,6 +78,8 @@ bool GodotcordUserManager::has_current_user_flag(GodotcordUserManager::UserFlag 
 void GodotcordUserManager::init() {
 	Godotcord::get_singleton()->get_core()->UserManager().OnCurrentUserUpdate.Connect([this]() {
 		print_verbose("Local Discord user updated");
+
+		emit_signal("local_user_updated");
 	});
 }
 


### PR DESCRIPTION
peer is not spelled "perr" ;P

(btw, I realized a year ago that I would have to implement a multiplayer peer on my own and because I have no real clue how c++ works I am happy that someone else did it 👍)