### PR TITLE
Add workflow dispatch and set fail fast to false

### DIFF
--- a/.github/workflows/build-download.yaml
+++ b/.github/workflows/build-download.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
     build:
@@ -30,6 +31,7 @@ jobs:
                   PLATFORM: windows
                   EXTENSION: 64.exe
                   AFTER_COMP_CMD: echo "Nothing to do"
+            fail-fast: false
         steps:
         - uses: actions/checkout@v2
           with: 


### PR DESCRIPTION
It makes it easy for developers to make a release and download because actions expire, if the actions fail, other actions are cancelled, so, fail-fast has been set to false which delays the failure of action.
I hope it's useful.