### PR TITLE
Fix macOS github actions

### DIFF
--- a/.github/workflows/build-download.yaml
+++ b/.github/workflows/build-download.yaml
@@ -17,19 +17,19 @@ jobs:
                   DOWNLOAD: brew install scons
                   PLATFORM: osx
                   EXTENSION: 64
-                  AFTER_COMP_CMD: install_name_tool -add_rpath @executable_path
+                  SCONS_OPTIONS: arch=x86_64 -j3
                 - os: ubuntu-latest
                   SETUP: ./setup.sh
                   DOWNLOAD: sudo apt update && sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
                   PLATFORM: x11
                   EXTENSION: 64
-                  AFTER_COMP_CMD: echo "Nothing to do"
+                  SCONS_OPTIONS: -j2
                 - os: windows-latest
                   SETUP: .\setup.bat
                   DOWNLOAD: python -m pip install scons
                   PLATFORM: windows
                   EXTENSION: 64.exe
-                  AFTER_COMP_CMD: echo "Nothing to do"
+                  SCONS_OPTIONS: -j2
         steps:
         - uses: actions/checkout@v2
           with: 
@@ -47,10 +47,7 @@ jobs:
         - run: ${{matrix.DOWNLOAD}}
 
         - name: Compile with target=release_debug
-          run: scons bits=64 target=release_debug -j2
-
-        - name: Modify binary after compilation
-          run: ${{matrix.AFTER_COMP_CMD}} bin/godot.${{matrix.PLATFORM}}.opt.tools.${{matrix.EXTENSION}}
+          run: scons bits=64 target=release_debug ${{matrix.SCONS_OPTIONS}}
 
         - name: Upload binary
           uses: actions/upload-artifact@v2
@@ -59,10 +56,7 @@ jobs:
             path: bin/godot.${{matrix.PLATFORM}}.opt.tools.${{matrix.EXTENSION}}
 
         - name: Compile with target=debug
-          run: scons bits=64 target=debug -j2
-
-        - name: Modify binary after compilation
-          run: ${{matrix.AFTER_COMP_CMD}} bin/godot.${{matrix.PLATFORM}}.tools.${{matrix.EXTENSION}}
+          run: scons bits=64 target=debug ${{matrix.SCONS_OPTIONS}}
 
         - name: Upload binary
           uses: actions/upload-artifact@v2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,14 +13,17 @@ jobs:
                   SETUP: ./setup.sh
                   DOWNLOAD: brew install scons
                   PLATFORM: osx
+                  SCONS_OPTIONS: arch=x86_64 -j3
                 - os: ubuntu-latest
                   SETUP: ./setup.sh
                   DOWNLOAD: sudo apt update && sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
                   PLATFORM: x11
+                  SCONS_OPTIONS: -j2
                 - os: windows-latest
                   SETUP: .\setup.bat
                   DOWNLOAD: python -m pip install scons
                   PLATFORM: windows
+                  SCONS_OPTIONS: -j2
         steps:
         - uses: actions/checkout@v2
           with: 
@@ -38,4 +41,4 @@ jobs:
         - run: ${{matrix.DOWNLOAD}}
 
         - name: Compile
-          run: scons bits=64 target=debug tools=no disable_3d=yes disable_advanced_gui=yes module_arkit_enabled=no module_bullet_enabled=no module_hdr_enabled=no module_camera_enabled=no module_enet_enabled=no module_mobile_vr_enabled=no module_websocket_enabled=no module_webrtc_enabled=no module_gdnative_enabled=no module_visual_script_enabled=no module_dds_enabled=no module_webp_enabled=no module_webm_enabled=no module_upnp_enabled=no -j2
+          run: scons bits=64 ${{matrix.SCONS_OPTIONS}} target=debug tools=no disable_3d=yes disable_advanced_gui=yes module_arkit_enabled=no module_bullet_enabled=no module_hdr_enabled=no module_camera_enabled=no module_enet_enabled=no module_mobile_vr_enabled=no module_websocket_enabled=no module_webrtc_enabled=no module_gdnative_enabled=no module_visual_script_enabled=no module_dds_enabled=no module_webp_enabled=no module_webm_enabled=no module_upnp_enabled=no

--- a/SCsub
+++ b/SCsub
@@ -63,7 +63,7 @@ def set_linker_vars():
         env.add_source_files(env.modules_sources, sources)
         env.Append(LIBPATH=['#modules/godotcord/libpath'])
         env.Append(LIBS=['discord_game_sdk'])
-        env.Append(RPATH=["."])
+        env.Append(LINKFLAGS=["-Wl,-rpath,@executable_path"])
 
 
 if env["platform"] != "server":


### PR DESCRIPTION
It seems that an update of the macOS version of the github actions runner caused the errors. The actions are fixed by changing the way the `rpath` option is passed to the linker. This should also eliminate the need to modify the rpath after compilation using `install_name_tool`. I do not own a macOS device so I can not check if the resulting binary works the way it did before. If anyone can test that please feel free to provide feedback.