### PR TITLE
Add XML docs (2)

### DIFF
--- a/.github/workflows/update-github-pages.yaml
+++ b/.github/workflows/update-github-pages.yaml
@@ -1,0 +1,34 @@
+name: Update gh pages
+on:
+  push:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/checkout@v2
+      with:
+        path: gh-pages
+        ref: gh-pages
+    - name: Parse docs
+      run: python3 doc_parse.py
+
+    - name: Move docs
+      run: mv docs/*.md gh-pages/
+
+    - name: Move navigation
+      run: mv docs/navigation.yml gh-pages/_data
+
+    - name: Set git identity
+      run: git config --global user.name "Doc update action" && git config --global user.email "admin@drachenfrucht1.de"
+ 
+    - name: Create commit
+      run: git add . && git commit -m "Update docs"
+      working-directory: gh-pages
+    
+    - name: Push
+      run: git push origin
+      working-directory: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 *.obj
 *.o
 build.txt
+docs/*.md
+docs/navigation.yml

--- a/config.py
+++ b/config.py
@@ -3,3 +3,31 @@ def can_build(env, platform):
 
 def configure(env):
     pass
+
+def get_doc_classes():
+    return [
+        "Godotcord",
+        "GodotcordAchievementManager",
+        "GodotcordActivity",
+        "GodotcordActivityManager",
+        "GodotcordFileStat",
+        "GodotcordImageManager",
+        "GodotcordInputMode",
+        "GodotcordLobby",
+        "GodotcordLobbyManager",
+        "GodotcordOverlayManager",
+        "GodotcordPresence",
+        "GodotcordRelationship",
+        "GodotcordRelationshipManager",
+        "GodotcordSearchParameter",
+        "GodotcordStorageManager",
+        "GodotcordStoreManager",
+        "GodotcordUser",
+        "GodotcordUserManager",
+        "GodotcordVoiceManager",
+        "NetworkedMultiplayerGodotcord"
+    ]
+
+
+def get_doc_path():
+    return "docs"

--- a/doc_parse.py
+++ b/doc_parse.py
@@ -1,0 +1,256 @@
+import xml.etree.ElementTree as ET
+from os import listdir
+from os.path import isfile, join, basename, splitext
+files = [f for f in listdir("docs") if isfile(join("docs", f))]
+
+navigation = "- title: Home\n"
+navigation += "  url: /\n"
+navigation += "- title: Classes\n"
+navigation += "  subfolderitems:\n"
+
+class GDClass:
+    def __init__(self, name):
+        self.name = name
+        self.brief_description = ""
+        self.description = ""
+        self.members = []
+        self.methods = []
+        self.signals = []
+        self.enums = {}
+
+    def print_class(self):
+        s = "# " + self.name + "\n\n"
+        s += self.brief_description.strip()
+        s += "\n"
+        s += "### Description\n\n"
+        s += self.description.strip()
+        s += "\n\n"
+
+        if len(self.members) > 0:
+            s += "| | |\n"
+            s += "----|----\n"
+            for m in self.members:
+                s += m.print_header()
+            s += "\n"
+
+        if len(self.methods) > 0:
+            s += "| | |\n"
+            s += "----|----\n"
+            for m in self.methods:
+                s += m.print_header()
+            s += "\n"
+
+        if len(self.signals) > 0:
+            s += "### Signals\n\n"
+            for sig in self.signals:
+                s += sig.print()
+
+        if len(self.enums) > 0:
+            s += "### Enumerations\n\n"
+            for k in self.enums:
+                s += self.enums[k].print()
+
+        if len([m for m in self.members if not(m.description is None)]) > 0:
+            s += "### Property Descriptions\n\n"
+            for m in self.members:
+                s += m.print_desc()
+
+        if len(self.methods) > 0:
+            s += "### Method Descriptions\n\n"
+            for m in self.methods:
+                s += m.print_desc()
+
+        s = s.replace("[code]", "`")
+        s = s.replace("[/code]", "`")
+
+        return s
+
+class GDMethod:
+    def __init__(self, name):
+        self.name = name
+        self.description = ""
+        self.returns = "void"
+        self.attributes = {}
+
+    def print_header(self):
+        s = self.returns + "|["  + self.name + "](#" + self.name + ")("
+
+        for k in sorted(self.attributes):
+            s += self.attributes[k] + ", "
+
+        s = "".join(s.rsplit(", ", 1))
+        s += ")\n"
+
+        return s
+
+    def print_desc(self):
+        s = "* <a name=\"" + self.name + "\"></a> " + self.returns + " "  + self.name + "("
+
+        for k in sorted(self.attributes):
+            s += self.attributes[k] + ", "
+
+        s = "".join(s.rsplit(", ", 1))
+        s += ")\n\n"
+        s += self.description.strip() + "\n\n"
+        s += "----\n"
+
+        return s
+
+class GDSignal:
+    def __init__(self, name):
+        self.name = name
+        self.description = ""
+        self.attributes = {}
+
+    def print(self):
+        s = "* " + self.name + "("
+
+        for k in sorted(self.attributes):
+            s += self.attributes[k] + ", "
+
+        s = "".join(s.rsplit(", ", 1))
+        s += ")\n\n"
+
+        s += self.description.strip() + "\n\n"
+        s += "----"
+        s += "\n"
+
+        return s
+
+class GDEnum:
+    def __init__(self, name):
+        self.name = name
+        self.members = {}
+
+    def add_value(self, name, value, desc):
+        self.members[value] = [name, desc]
+
+    def print(self):
+        s = "enum **" + self.name + "**\n\n"
+        for k in sorted(self.members):
+            s += "* **" + self.members[k][0] + "**=**" + k + "** --- " + self.members[k][1].strip() + "\n"
+        s+= "\n----\n"
+
+        return s
+
+class GDProperty:
+    def __init__(self, name, t, setter, getter, default, description):
+        self.name = name
+        self.type = t
+        self.setter = setter
+        self.getter = getter
+        self.default = default
+        self.description = description
+
+    def print_header(self):
+        return  self.type + "|["  + self.name + "](#" + self.name + ")|" + self.default + "\n"
+
+    def print_desc(self):
+        if self.description is None:
+            return ""
+
+        s = "* <a name=\"" + self.name + "\"></a> " + self.type + " "  + self.name + "\n\n"
+
+        s += "| | |\n"
+        s += "|----|----|\n"
+        if self.default == "":
+            s += "*Default*|`\"\"`\n"
+        else: 
+            s += "*Default*|`" + self.default + "`\n"
+        s += "*Setter*|" + self.setter + "(value)\n"
+        s += "*Getter*|" + self.getter + "\n"
+
+        s += self.description.strip() + "\n\n"
+        s += "----\n"
+
+        return s
+
+def get_constants(gdclass, constants):
+    for child in constants:
+        if child.attrib["enum"] in gdclass.enums:
+            gdclass.enums[child.attrib["enum"]].add_value(child.attrib["name"], child.attrib["value"], child.text)
+        else:
+            enum = GDEnum(child.attrib["enum"])
+            enum.add_value(child.attrib["name"], child.attrib["value"], child.text)
+            gdclass.enums[child.attrib["enum"]] = enum
+
+def get_method(gdclass, method):
+    m = GDMethod(method.attrib["name"])
+    for child in method:
+        if child.tag == "description":
+            m.description = child.text
+        elif child.tag == "argument":
+            s = child.attrib["name"]  + " : "
+            if "enum" in child.attrib:
+                s += child.attrib["enum"]
+            else:
+                s += child.attrib["type"]
+            if "default" in child.attrib:
+                s += " = " + child.attrib["default"]
+            m.attributes[child.attrib["index"]] = s
+        elif child.tag == "returns":
+            if "enum" in child.attrib:
+                m.returns = child.attrib["enum"]
+            else:
+                m.returns = child.attrib["type"]
+
+
+    gdclass.methods.append(m)
+
+def get_signal(gdclass, signal):
+    m = GDSignal(signal.attrib["name"])
+    for child in signal:
+        if child.tag == "description":
+            m.description = child.text
+        elif child.tag == "argument":
+            s = child.attrib["name"]  + " : "
+            if "enum" in child.attrib:
+                s += child.attrib["enum"]
+            else:
+                s += child.attrib["type"]
+            if "default" in child.attrib:
+                s += " = " + child.attrib["default"]
+            m.attributes[child.attrib["index"]] = s
+
+    gdclass.signals.append(m)
+
+def get_member(gdclass, member):
+    m = GDProperty(member.attrib["name"], member.attrib["type"], member.attrib["getter"], member.attrib["setter"], member.attrib["default"], member.text)
+    gdclass.members.append(m)
+
+def print_class(file, gdclass):
+    f = open(join("docs", splitext(basename(file))[0] + ".md"), "w")
+    f.write(gdclass.print_class())
+    f.close()
+
+for f in files:
+    if splitext(basename(f))[1] != ".xml":
+        continue
+    print("Parsing " + f)
+    tree = ET.parse(join("docs", f))
+    root = tree.getroot()
+    gdclass = GDClass(root.attrib["name"])
+    for child in root:
+        if child.tag == "brief_description":
+            gdclass.brief_description = child.text
+        elif child.tag == "description":
+            gdclass.description = child.text
+        elif child.tag == "methods":
+            for method in child:
+                get_method(gdclass, method)
+        elif child.tag == "signals":
+            for signal in child:
+                get_signal(gdclass, signal)
+        elif child.tag == "members":
+            for member in child:
+                get_member(gdclass, member)
+        elif child.tag == "constants":
+            get_constants(gdclass, child)
+    print_class(f, gdclass)
+
+    navigation += "    - page: " + gdclass.name + "\n"
+    navigation += "      url: " + gdclass.name + ".html\n"
+
+f = open(join("docs", "navigation.yml"), "w")
+f.write(navigation)
+f.close() 

--- a/docs/Godotcord.xml
+++ b/docs/Godotcord.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Godotcord" inherits="Object" version="0.1">
+    <brief_description>
+       
+    </brief_description>
+    <description>
+        
+    </description>
+    <methods>
+        <method name="init">
+            <argument index="0" name="client_id" type="int">
+            </argument>
+            <argument index="1" name="createFlags" type="CreateFlags">
+            </argument>
+            <description>
+                
+            </description>
+        </method>
+        <method name="init_debug">
+            <argument index="0" name="client_id" type="int">
+            </argument>
+            <argument index="1" name="id" type="string">
+            </argument>
+            <argument index="2" name="createFlags" type="CreateFlags">
+            </argument>
+            <description>
+                
+            </description>
+        </method>
+        <method name="run_callbacks">
+            <description>
+                Runs all the callbacks from the Discord Game SDK.
+                This should be run every frame.
+            </description>
+        </method>
+        <method name="is_init">
+            <returns type="bool">
+            </returns>
+            <description>
+                Returns whether Godotcord is initialized.
+            </description>
+        </method>
+    </methods>
+    <constants>
+        <constant name="CreateFlags_DEFAULT" value="0" enum="CreateFlags">
+
+        </constant>
+        <constant name="CreateFlags_NO_REQUIRE_DISCORD" value="1" enum="CreateFlags">
+
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordAchievementManager.xml
+++ b/docs/GodotcordAchievementManager.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordAchievementManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Achievement Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Activity Manager. This class is used to organise the achievements of the local user.
+    </description>
+    <methods>
+        <method name="set_user_achievement">
+            <argument index="0" name="achievement_id" type="int">
+            </argument>
+            <argument index="1" name="percent" type="int">
+            </argument>
+            <description>
+                Sets the achievement [code]achievement[/code] to be [code]percent[/code] completed.
+            </description>
+        </method>
+        <method name="fetch_user_achievement">
+            <description>
+                Fetched the users achievements. Emitts [code]fetch_user_achievements[/code] when the fetching is complete.
+            </description>
+        </method>
+        <method name="get_user_achievements">
+            <returns type="Array">
+            </returns>
+            <description>
+                Returns all achievements and their progress.
+            </description>
+        </method>
+    </methods>
+    <signals>
+        <signal name="fetch_user_achievements">
+            <description>
+                Emitted when the user achievements have been fetched.
+            </description>
+        </signal>
+    </signals>
+</class>

--- a/docs/GodotcordActivity.xml
+++ b/docs/GodotcordActivity.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordActivity" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for the discord game activity
+    </brief_description>
+    <description>
+        Data class for the discord game activity. 
+    </description>
+    <members>
+        <member name="state" type="string" setter="set_state" getter="get_state" override="true" default="" />
+        <member name="details" type="string" setter="set_details" getter="get_details" override="true" default="" />
+        <member name="large_image" type="string" setter="set_large_image" getter="get_large_image" override="true" default="" />
+        <member name="large_text" type="string" setter="set_large_text" getter="get_large_text" override="true" default="" />
+        <member name="small_image" type="string" setter="set_small_image" getter="get_small_image" override="true" default="" />
+        <member name="small_text" type="string" setter="set_small_text" getter="get_small_text" override="true" default="" />
+        
+        <member name="party_id" type="string" setter="set_party_id" getter="get_party_id" override="true" default="" />
+        <member name="party_max" type="int" setter="set_party_max" getter="get_party_max" override="true" default="-1" />
+        <member name="party_current" type="int" setter="set_party_current" getter="get_party_current" override="true" default="-1" />
+
+        <member name="match_secret" type="string" setter="set_match_secret" getter="get_match_secret" override="true" default="" />
+        <member name="join_secret" type="string" setter="set_join_secret" getter="get_join_secret" override="true" default="" />
+        <member name="spectate_secret" type="string" setter="set_spectate_secret" getter="get_spectate_secret" override="true" default="" />
+
+        <member name="start" type="int" setter="set_start" getter="get_start" override="true" default="0" />
+        <member name="end" type="int" setter="set_end" getter="get_end" override="true" default="0" />
+
+        <member name="application_id" type="int" setter="set_application_id" getter="get_application_id" override="true" default="0" />
+    </members>
+    <constants>
+        <constant name="NO" value="0" enum="ActivityRequestReply">
+            Reject the request
+        </constant>
+        <constant name="YES" value="1" enum="ActivityRequestReply">
+            Accept the request
+        </constant>
+        <constant name="IGNORE" value="2" enum="ActivityRequestReply">
+            Ignore the request
+        </constant>
+
+        <constant name="JOIN" value="1" enum="ActivityActionType">
+            Marks a join request
+        </constant>
+        <constant name="SPECTATE" value="2" enum="ActivityActionType">
+            Marks a spectate request
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordActivityManager.xml
+++ b/docs/GodotcordActivityManager.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordActivityManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Activity Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Activity Manager. This class is used to manage the rich presence of the user and to receive and send game invites via Discord.
+        It is provided as a singleton named GodotcordActivityManger
+    </description>
+    <methods>
+        <method name="set_activity">
+            <argument index="0" name="activity" type="GodotcordActivity">
+            </argument>
+            <description>
+                Set the game activity to the provided activity.
+            </description>
+        </method>
+        <method name="clear_activity">
+            <description>
+                Removes the current game activity.
+            </description>
+        </method>
+        <method name="register_steam">
+            <argument index="0" name="steam_id" type="int">
+            </argument> 
+            <description>
+                Register the steam id of the game. Used by Discord to launch the game when pressing on an invite.
+            </description>
+        </method>
+        <method name="register_command">
+            <argument index="0" name="command" type="string">
+            </argument>
+            <description>
+                Register a command that launches the game. Used by Discord to launch the game when pressing on an invite.
+            </description>
+        </method>
+        <method name="send_request_reply">
+            <argument index="0"  name="user_id" type="int">
+            </argument>
+            <argument index="1" name="reply" type="int" enum="GodotcordActivity.ActivityRequestReply"></argument>
+            <description>
+                Answers the request received by [code]user_id[/code] with the provided reply.
+            </description>
+        </method>
+        <method name="send_invite">
+            <argument index="0" name="user_id" type="int">
+            </argument>
+            <argument index="1" name="type" type="int" enum="GodotcordActivity.ActivityActionType">
+            </argument>
+            <argument index="2" name="message" type="string">
+            </argument>
+            <description>
+                Sends an invite of type [code]type[/code] to [code]user_id[/code] with the message [code]message[/code]
+            </description>
+        </method>
+        <method name="accept_invite">
+            <argument index="0" name="user_id" type="int" >
+            </argument>
+            <description>
+                Accepts the invite received by [code]user_id[/code]
+            </description>
+        </method>
+    </methods>
+    <signals>
+        <signal name="activity_join_request">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <argument index="1" name="user_id" type="int">
+            </argument>
+            <description>
+                Emitted when a join request has been send by the user with the name [code]name[/code] and user id [code]user_id[/code]
+            </description>
+        </signal>
+        <signal name="activity_invite">
+            <argument index="0" name="type" type="int" enum="GodotcordActivity.ActivityActionType">
+            </argument>
+            <argument index="1" name="name" type="string">
+            </argument>
+            <argument index="2" name="user_id" type="int">
+            </argument>
+            <argument index="3" name="activity" type="Dictionary">
+            </argument>
+            <description>
+                Emitted when a join/spectate request is received.
+            </description>
+        </signal>
+        <signal name="acvitiy_join">
+            <argument index="0" name="activity_secret" type="string">
+            </argument>
+            <description>
+                Emitted when a chat invite has been pressed or a join request has been accepted.
+            </description>
+        </signal>
+        <signal name="activity_spectate">
+            <argument index="0" name="activity_secret" type="string">
+            </argument>
+            <description>
+                Emmitted when a spectate request has been accepted.
+            </description>
+        </signal>
+    </signals>
+    <constants>
+
+    </constants>
+</class>

--- a/docs/GodotcordFileStat.xml
+++ b/docs/GodotcordFileStat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordFileStat" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for the discord file stat
+    </brief_description>
+    <description>
+        Data class for the discord file stat. 
+    </description>
+    <members>
+        <member name="file_name" type="string" setter="set_file_name" getter="get_file_name" override="true" default="" />
+        <member name="last_modified" type="int" setter="set_last_modified" getter="get_last_modified" override="true" default="0" />
+        <member name="size" type="int" setter="set_size" getter="get_size" override="true" default="0" />
+    </members>
+</class>

--- a/docs/GodotcordImageManager.xml
+++ b/docs/GodotcordImageManager.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordImageManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Achievement Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Activity Manager. This class is used to fetch the profile image of users.
+    </description>
+    <methods>
+        <method name="get_profile_picture">
+            <argument index="0" name="user_id" type="int">
+            </argument>
+            <argument index="1" name="size" type="int">
+            </argument>
+            <description>
+                Fetches the profile picture of user [code]user_id[/code].
+                Emitts the signal [code]profile_picture_callback[/code] with the image data cropped to [code]size*size[/code] pixels.
+            </description>
+        </method>
+    </methods>
+    <signals>
+        <signal name="profile_picture_callback">
+            <argument index="0" name="user_id" type="int">
+            </argument>
+            <argument index="1" name="image_data" type="PoolByteArray">
+            </argument>
+            <description>
+                Emitted when a profile picture has been fetched. The image data is returned as a byte array in [code]image_data[/code].
+                See the example on how to convert the raw image data into a texture to use it in Godot.
+            </description>
+        </signal>
+    </signals>
+</class>

--- a/docs/GodotcordInputmode.xml
+++ b/docs/GodotcordInputmode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordInputMode" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for the discord input mode.
+    </brief_description>
+    <description>
+        Data class for the discord input mode.
+    </description>
+    <members>
+        <member name="type" type="InputModeType" setter="set_type" getter="get_type" override="true" default="" />
+        <member name="shortcut" type="string" setter="set_shortcut" getter="get_shortcut" override="true" default="0" />
+    </members>
+    <constants>
+        <constant name="VOICE_ACTIVITY" value="0" enum="InputModeType">
+        </constant>
+        <constant name="PUSH_TO_TALK" value="1" enum="InputModeType">
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordLobby.xml
+++ b/docs/GodotcordLobby.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordLobby" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for a discord lobby
+    </brief_description>
+    <description>
+        Data class for a discord lobby
+    </description>
+    <methods>
+        <method name="get_secret">
+            <returns type="string"></returns>
+        </method>
+        <method name="set_secret">
+            <argument index="0" name="property" type="string"></argument>
+        </method>
+        <method name="get_id">
+            <returns type="int"></returns>
+        </method>
+        <method name="set_id">
+            <argument index="0" name="property" type="int"></argument>
+        </method>
+        <method name="get_owner_id">
+            <returns type="int"></returns>
+        </method>
+        <method name="set_owner_id">
+            <argument index="0" name="property" type="int"></argument>
+        </method>
+        <method name="get_max_users">
+            <returns type="int"></returns>
+        </method>
+        <method name="set_max_users">
+            <argument index="0" name="property" type="int"></argument>
+        </method>
+        <method name="get_current_users">
+            <returns type="int"></returns>
+        </method>
+        <method name="set_current_users">
+            <argument index="0" name="property" type="int"></argument>
+        </method>
+    </methods>
+    <members>
+        <member name="secret" type="string" setter="set_secret" getter="get_secret" override="false" default=""></member>
+        <member name="id" type="int" setter="set_id" getter="get_id" override="false" default="0"></member>
+        <member name="owner_id" type="int" setter="set_owner_id" getter="get_owner_id" override="false" default="0"></member>
+        <member name="max_users" type="int" setter="set_max_users" getter="get_max_users" override="false" default="0"></member>
+        <member name="current_users" type="int" setter="set_current_users" getter="get_current_users" override="false" default="0"></member>
+    </members>
+</class>

--- a/docs/GodotcordLobbyManager.xml
+++ b/docs/GodotcordLobbyManager.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordLobbyManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Achievement Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Activity Manager. This class is used to search lobbies and manipulate their metadata.
+    </description>
+    <methods>
+        <method name="set_lobby_metadata">
+            <argument index="0" name="lobby_id" type="int">
+            </argument>
+            <argument index="1" name="key" type="string">
+            </argument>
+            <argument index="2" name="value" type="string" ></argument>
+            <description>
+                Sets the key/value pair as metadata of the lobby [code]lobby_id[/code]. 
+                The local user has be the owner of the lobby. Otherwise nothing will happen.
+                Overwrites the value if the key already exists(?).
+            </description>
+        </method>
+        <method name="get_lobby_metadata" >
+            <argument index="0" name="lobby_id" type="int">
+            </argument>
+            <argument index="1" name="key" type="string">
+            </argument>
+            <returns type="string">
+            </returns>
+            <description>
+                Returns the value associated with the key.
+            </description>
+        </method>
+        <method name="search_lobbies">
+            <argument index="0" name="parameters" type="Variant">
+            </argument>
+            <argument index="1" name="limit" type="int">
+            </argument>
+            <description>
+                Searches all lobbies for ones that match the provided parameters.
+                Returns at most [code]limit[/code] lobbies via the Signal [code]search_lobbies_callback[/code].
+            </description>
+        </method>
+    </methods>
+    <signals>
+        <signal name="search_lobbies_callback">
+            <argument index="0" name="lobbies" type="Array">
+            </argument>
+            <description>
+                Emitted after a lobby search has been completed.
+            </description>
+        </signal>
+    </signals>
+    <constants>
+        <constant name="LOCAL" value="0" enum="LobbyDistance">
+            Lobbies in the same region
+        </constant>
+        <constant name="DEFAULT" value="1" enum="LobbyDistance">
+            Lobbies in adjacent regions.
+        </constant>
+        <constant name="Extended" value="2" enum="LobbyDistance">
+            Lobbies in regions far apart, e.g. Europe and the US
+        </constant>
+        <constant name="GLOBAL" value="3" enum="LobbyDistance">
+            Lobbies from all around the world.
+        </constant>
+
+        <constant name="LESS_THAN_OR_EQUAL" value="0" enum="LobbyComparison">
+            
+        </constant>
+        <constant name="LESS_THAN" value="1" enum="LobbyComparison">
+            
+        </constant>
+        <constant name="EQUAL" value="2" enum="LobbyComparison">
+            ==
+        </constant>
+        <constant name="GREATER_THAN" value="3" enum="LobbyComparison">
+            
+        </constant>
+        <constant name="GREATER_THAN_OR_EQUAL" value="4" enum="LobbyComparison">
+            
+        </constant>
+        <constant name="NOT_EQUAL" value="6" enum="LobbyComparison">
+            !=
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordOverlayManager.xml
+++ b/docs/GodotcordOverlayManager.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordOverlayManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Overlay Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Activity Manager. This class is used to interface with the ingame discord overlay.
+    </description>
+    <methods>
+        <method name="is_enabled">
+            <returns type="boolean">
+            </returns>
+            <description>
+                Returns whether the overlay is enabled
+            </description>
+        </method>
+        <method name="is_locked">
+            <returns type="boolean">
+            </returns>
+            <description>
+                Returns whether the overlay is locked
+            </description>
+        </method>
+        <method name="set_locked">
+            <argument index="0" name="locked" type="boolean">
+            </argument>
+            <description>
+                The the locking status to [code]locked[/code].
+            </description>
+        </method>
+        <method name="open_voice_settings">
+            <description>
+                Signals the overlay to open the voice settings.
+            </description>
+        </method>
+        <method name="open_activity_invite">
+            <argument index="0" name="type" type="ActivityActionType">
+            </argument>
+            <description>
+                Opens a dialog to send activity invites to user, channels, groups, ...
+            </description>
+        </method>
+        <method name="open_build_invite">
+            <argument index="0" name="invite_code" type="string">
+            </argument>
+            <description>
+                Opens the "Join a guild" dialog with the specified invite code.
+            </description>
+        </method>
+    </methods>
+    <signals>
+        <signal name="profile_picture_callback">
+            <argument index="0" name="user_id" type="int">
+            </argument>
+            <argument index="1" name="image_data" type="PoolByteArray">
+            </argument>
+            <description>
+                Emitted when a profile picture has been fetched. The image data is returned as a byte array in [code]image_data[/code].
+                See the example on how to convert the raw image data into a texture to use it in Godot.
+            </description>
+        </signal>
+    </signals>
+</class>

--- a/docs/GodotcordPresence.xml
+++ b/docs/GodotcordPresence.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordPresence" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for a discord presence
+    </brief_description>
+    <description>
+        Data class for a discord presence
+    </description>
+    <methods>
+        <method name="get_status">
+            <returns type="PresenceStatus"></returns>
+        </method>
+        <method name="set_status">
+            <argument index="0" name="property" type="PresenceStatus"></argument>
+        </method>
+        <method name="get_activity">
+            <returns type="GodotcordActivity"></returns>
+        </method>
+        <method name="set_activity">
+            <argument index="0" name="property" type="GodotcordActivity"></argument>
+        </method>
+    </methods>
+    <members>
+        <member name="status" type="PresenceStatus" setter="set_status" getter="get_status" override="false" default=""></member>
+        <member name="activity" type="GodotcordActivity" setter="set_activity" getter="get_activity" override="false" default="0"></member>
+    </members>
+    <constants>
+        <constant name="OFFLINE" value="0" enum="PresenceStatus">
+            The user is currently offline
+        </constant>
+        <constant name="ONLINE" value="1" enum="PresenceStatus">
+            The user is currently online
+        </constant>
+        <constant name="IDLE" value="2" enum="PresenceStatus">
+            The user is currently idling
+        </constant>
+        <constant name="DO_NOT_DISTURB" value="3" enum="PresenceStatus">
+            The users status is do not disturb
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordRelationship.xml
+++ b/docs/GodotcordRelationship.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordRelationship" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for a discord relationship
+    </brief_description>
+    <description>
+        Data class for a discord relationship
+    </description>
+    <methods>
+        <method name="get_type">
+            <returns type="RelationshipStatus"></returns>
+        </method>
+        <method name="set_type">
+            <argument index="0" name="property" type="RelationshipStatus"></argument>
+        </method>
+        <method name="get_user_id">
+            <returns type="int"></returns>
+        </method>
+        <method name="set_user_id">
+            <argument index="0" name="property" type="int"></argument>
+        </method>
+        <method name="get_presence">
+            <returns type="GodotcordPresence"></returns>
+        </method>
+        <method name="set_presence">
+            <argument index="0" name="property" type="GodotcordPresence"></argument>
+        </method>
+    </methods>
+    <members>
+        <member name="type" type="RelationshipType" setter="set_type" getter="get_type" override="false" default=""></member>
+        <member name="user_id" type="int" setter="set_user_id" getter="get_user_id" override="false" default="0"></member>
+        <member name="presence" type="GodotcordPresence" setter="set_presence" getter="get_presence" override="false" default="0"></member>
+    </members>
+    <constants>
+        <constant name="NONE" value="0" enum="RelationshipType">
+            The user has no intrinsic relationship
+        </constant>
+        <constant name="FRIEND" value="1" enum="RelationshipType">
+            The user is a friend
+        </constant>
+        <constant name="BLOCKED" value="2" enum="RelationshipType">
+            The user is blocked
+        </constant>
+        <constant name="PENDING_INCOMING" value="3" enum="RelationshipType">
+            The current user has a pending incoming friend request from the user
+        </constant>
+        <constant name="PENDING_OUTGOING" value="4" enum="RelationshipType">
+            The current user has a pending outgoing friend request to the user
+        </constant>
+        <constant name="IMPLICIT" value="5" enum="RelationshipType">
+            The user is no friend but they interact often
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordRelationshipManager.xml
+++ b/docs/GodotcordRelationshipManager.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordRelationshipManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Relationship Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Relationship Manager. This class is used to fetch the users relationships.
+    </description>
+    <methods>
+        <method name="filter_relationships">
+            <argument index="0" name="object" type="Object">
+            </argument>
+            <argument index="1" name="function_name" type="string">
+            </argument>
+            <returns type="Array"></returns>
+            <description>
+                Fetches the users relationships and filters them using the provided function of the provided object. 
+                The function has to a GodotcordRelationship as parameter and must return a boolean. The boolean indicates whether the relationship should be included in the list or not.
+                Returns an array containing all filtered relationships.
+            </description>
+        </method>
+        <method name="get_relationships">
+            <returns type="Array"></returns>
+            <description>
+                Returns an array containing all relationships using the last filter.
+            </description>
+        </method>
+    </methods>
+</class>

--- a/docs/GodotcordSearchParameter.xml
+++ b/docs/GodotcordSearchParameter.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordSearchParameter" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for a discord lobby
+    </brief_description>
+    <description>
+        Data class for a discord lobby
+    </description>
+    <methods>
+        <method name="get_property">
+            <returns type="string"></returns>
+        </method>
+        <method name="set_property">
+            <argument index="0" name="property" type="string"></argument>
+        </method>
+        <method name="get_comparison">
+            <returns type="LobbyComparison"></returns>
+        </method>
+        <method name="set_comparison">
+            <argument index="0" name="property" type="LobbyComparison"></argument>
+        </method>
+        <method name="get_cast">
+            <returns type="LobbyCast"></returns>
+        </method>
+        <method name="set_cast">
+            <argument index="0" name="property" type="LobbyCast"></argument>
+        </method>
+        <method name="get_value">
+            <returns type="string"></returns>
+        </method>
+        <method name="set_value">
+            <argument index="0" name="property" type="string"></argument>
+        </method>
+    </methods>
+    <members>
+        <member name="property" type="string" setter="set_property" getter="get_property" override="false" default=""></member>
+        <member name="comparison" type="LobbyComparison" setter="set_comparison" getter="get_comparison" override="false" default="0"></member>
+        <member name="cast" type="LobbyCast" setter="set_cast" getter="get_cast" override="false" default="0"></member>
+        <member name="value" type="int" setter="set_value" getter="get_value" override="false" default="0"></member>
+    </members>
+</class>

--- a/docs/GodotcordStorageManager.xml
+++ b/docs/GodotcordStorageManager.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordStorageManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Storage Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Storage Manager. This class is used to manage save games in the cloud.
+    </description>
+    <methods>
+        <method name="get_path">
+            <returns type="string"></returns>
+        </method>
+        <method name="read">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <returns type="Array"></returns>
+            <description>
+                Returns the content of file [code]name[/code]
+            </description>
+        </method>
+        <method name="read_async">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <returns type="Array"></returns>
+            <description>
+                Reads the content of [code]name[/code] asnychronously.
+                Returns the content using the [code]async_data_read[/code] signal.
+            </description>
+        </method>
+        <method name="read_async_partial">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <argument index="1" name="offset" type="int">
+            </argument>
+            <argument index="2" name="length" type="int">
+            </argument>
+            <returns type="Array"></returns>
+            <description>
+                Reads [code]length[/code] bytes beginning from the [code]offset[/code]th byte from the file [code]name[/code] asnychronously.
+                Returns the content using the [code]async_data_read[/code] signal.
+            </description>
+        </method>
+        <method name="write">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <argument index="0" name="data" type="Array">
+            </argument>
+        </method>
+        <method name="write_async">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <argument index="0" name="data" type="Array">
+            </argument>
+            <description>
+                Emits the signal [code]async_data_written[/code] after the completion.
+            </description>
+        </method>
+        <method name="destroy">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <description>
+                Destroys the file [code]name[/code].
+            </description>
+        </method>
+        <method name="exists">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <returns type="bool"></returns>
+            <description>
+                Returns whether the file [code]name[/code] exists.
+            </description>
+        </method>
+        <method name="stat">
+            <argument index="0" name="name" type="string">
+            </argument>
+            <returns type="GodotcordFileStat"></returns>
+            <description>
+                Returns the GodotcordFileStat for the file [code]name[/code].
+            </description>
+        </method>
+        <method name="count">
+            <returns type="int"></returns>
+        </method>
+        <method name="stat_at">
+            <argument index="0" name="index" type="int">
+            </argument>
+            <returns type="GodotcordFileStat"></returns>
+        </method>
+    </methods>
+</class>

--- a/docs/GodotcordStoreManager.xml
+++ b/docs/GodotcordStoreManager.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordStoreManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Store Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Store Manager.
+    </description>
+    <methods>
+        <method name="fetch_skus">
+        </method>
+        <method name="get_skus">
+            <returns type="Array"></returns>
+        </method>
+        <method name="fetch_entitlements">
+            <description>
+                Refetches the entitlements of the local user
+            </description>
+        </method>
+        <method name="fetch_entitlements">
+            <returns type="Array"></returns>
+            <description>
+                Returns the entitlements of the local user.
+            </description>
+        </method>
+        <method name="fetch_entitlements">
+            <argument index="0" name="sku_id" type="int">
+            </argument>
+            <returns type="bool"></returns>
+            <description>
+                Returns whether the local user has an entitlement for the sku [code]sku_id[/code].
+            </description>
+        </method>
+        <method name="start_purchase">
+            <argument index="0" name="sku_id" type="int">
+            </argument>
+            <description>
+                Opens the discord client and starts a purchase dialog for the sku [code]sku_id[/code].
+            </description>
+        </method>
+    </methods>
+</class>

--- a/docs/GodotcordUser.xml
+++ b/docs/GodotcordUser.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordUser" inherits="Reference" version="0.1">
+    <brief_description>
+        Data class for a discord user.
+    </brief_description>
+    <description>
+        Data class for a discord user.
+    </description>
+    <members>
+        <member name="id" type="int" setter="set_id" getter="get_id" override="true" default="0" />
+        <member name="name" type="string" setter="set_name" getter="get_name" override="true" default="" />
+        <member name="discriminator" type="string" setter="set_discriminator" getter="get_discriminator" override="true" default="" />
+        <member name="avatar" type="string" setter="set_avatar" getter="get_avatar" override="true" default="" />
+        <member name="bot" type="bool" setter="set_bot" getter="get_bot" override="true" default="false" />
+    </members>
+</class>

--- a/docs/GodotcordUserManager.xml
+++ b/docs/GodotcordUserManager.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordUserManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK User Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK User Manager.
+    </description>
+    <methods>
+        <method name="get_user">
+            <argument index="1" type="int" name="user_id">
+            </argument>
+            <description>
+                Request the user object of [code]user_id[/code].
+                The user object is returned via the [code]get_user_callback[/code] signal.
+            </description>
+        </method>
+        <method name="get_current_user">
+            <returns type="GodotcordUser"></returns>
+            <description>
+                Returns the user objects of the local user.
+            </description>
+        </method>
+        <method name="get_current_user_premium_type">
+            <returns type="PremiumType">
+            </returns>
+            <description>
+                Returns the premium type of the local user.
+            </description>
+        </method>
+        <method name="has_current_user_flag">
+            <argument index="1" name="flag" type="UserFlag">
+            </argument>
+            <returns type="bool"></returns>
+            <description>
+                Returns whether the local user has [code]flag[/code].
+            </description>
+        </method>
+    </methods>
+    <constants>
+        <constant name="PARTNER" value="2" enum="UserFlag">
+            The user is a discord partner.
+        </constant>
+        <constant name="HYPE_SQUAD_EVENTS" value="4" enum="UserFlag">
+            The user is a hypesquad events participant
+        </constant>
+        <constant name="HYPE_SQUAD_HOUSE_1" value="64" enum="UserFlag">
+            The user is a member of the house of bravery.
+        </constant>
+        <constant name="HYPE_SQUAD_HOUSE_2" value="128" enum="UserFlag">
+            The user is a member of the house of brilliance.
+        </constant>
+        <constant name="HYPE_SQUAD_HOUSE_3" value="256" enum="UserFlag">
+            The user is a  member of the house of balance.
+        </constant>
+        <constant name="ERROR" value="-1" enum="PremiumType">
+            An error has occured while retrieving the premium type.
+        </constant>
+        <constant name="NONE" value="0" enum="PremiumType">
+            The user is not a nitro subscriber.
+        </constant>
+        <constant name="TIER_1" value="1" enum="PremiumType">
+            The user is a nitro classic subscriber.
+        </constant>
+        <constant name="TIER_2" value="2" enum="PremiumType">
+            The user is a nitro subscriber.
+        </constant>
+    </constants>
+</class>

--- a/docs/GodotcordVoiceManager.xml
+++ b/docs/GodotcordVoiceManager.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotcordVoiceManager" inherits="Object" version="0.1">
+    <brief_description>
+        A wrapper of the Discord Game SDK Voice Manager.
+    </brief_description>
+    <description>
+        A wrapper of the Discord Game SDK Voice Manager.
+    </description>
+    <methods>
+        <method name="get_input_mode">
+            <returns type="GodotcordInputMode">
+            </returns>
+            <description>
+            </description>
+        </method>
+        <method name="set_voice_activity">
+            <description>
+                Sets the input mode to voice activity.
+            </description>
+        </method>
+        <method name="set_push_to_talk">
+            <argument index="0" type="string" name="hotkey">
+            </argument>
+            <description>
+                Sets the input mode to push to talk with the hotkey [code]hotkey[/code].
+            </description>
+        </method>
+        <method name="is_self_mute">
+            <returns type="bool"></returns>
+            <description>
+                Returns whether the local user is self mute.
+            </description>
+        </method>
+        <method name="set_self_mute">
+            <argument index="0" type="bool" name="b">
+            </argument>
+            <description>
+            </description>
+        </method>
+        <method name="set_push_to_talk">
+            <argument index="0" type="string" name="hotkey">
+            </argument>
+            <description>
+                Sets the input mode to push to talk with the hotkey [code]hotkey[/code].
+            </description>
+        </method>
+        <method name="is_self_deaf">
+            <returns type="bool"></returns>
+            <description>
+                Returns whether the local user is self deaf.
+            </description>
+        </method>
+        <method name="set_self_deaf">
+            <argument index="0" type="bool" name="b">
+            </argument>
+            <description>
+            </description>
+        </method>
+        <method name="set_push_to_talk">
+            <argument index="0" type="string" name="hotkey">
+            </argument>
+            <description>
+                Sets the input mode to push to talk with the hotkey [code]hotkey[/code].
+            </description>
+        </method>
+        <method name="is_local_mute">
+            <argument index="0" type="int" name="user_id">
+            </argument>
+            <returns type="bool"></returns>
+            <description>
+                Returns whether [code]user_id[/code] is muted by the local user.
+            </description>
+        </method>
+        <method name="set_local_mute">
+            <argument index="0" type="int" name="user_id">
+            </argument>
+            <argument index="1" type="bool" name="b">
+            </argument>
+            <description>
+            </description>
+        </method>
+        <method name="is_local_volume">
+            <argument index="0" type="int" name="user_id">
+            </argument>
+            <returns type="int"></returns>
+            <description>
+                Returns the local volume of [code]user_id[/code].
+                The value range is 0 to 200.
+            </description>
+        </method>
+        <method name="set_local_mute">
+            <argument index="0" type="int" name="user_id">
+            </argument>
+            <argument index="1" type="int" name="b">
+            </argument>
+            <description>
+                The value range is 0 to 200.
+            </description>
+        </method>
+    </methods>
+</class>

--- a/docs/NetworkedMultiplayerGodotcord.xml
+++ b/docs/NetworkedMultiplayerGodotcord.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NetworkedMultiplayerGodotcord" inherits="NetworkedMultiplayerPeer" version="0.1">
+    <brief_description>
+        A multiplayer peer that uses the Discord Network
+    </brief_description>
+    <description>
+        A multiplayer peer that uses the Discord Network.
+        There are multiple id's connected with multiplayer. The first on is the peer id.
+        It is used to identify a user in a lobby. It can however not be used to retrieve other data of a user (e.g. profile picture).
+        The peer id will be set as the sender if of rcp calls.
+        The other one is the user id. It can be used to retrieve additional information about a user.
+        You can convert from one to the other using [code]get_user_id_by_peer[/code] and [code]get_peer_id_by_user[/code]
+    </description>
+    <methods>
+        <method name="create_lobby">
+            <argument index="0" name="max_users" type="int">
+            </argument>
+            <argument index="1" name="public" type="boolean" default="false">
+            </argument>
+            <description>
+                Creates a new lobby with [code]max_users[/code] slots.
+                The creator will automatically set as the owner and joins the lobby himself.
+
+                ...public
+            </description>
+        </method>
+        <method name="join_lobby">
+            <argument index="0" name="lobby_id" type="int">
+            </argument> 
+            <argument index="1" name="secret" type="string">
+            </argument>
+            <description>
+                Joins the lobby with the id [code]lobby_id[/code] using the id and secret.
+            </description>
+        </method>
+        <method name="join_lobby_activity">
+            <argument index="0" name="activity_secret" type="string">
+            </argument>
+            <description>
+                Joins the lobby encoded in [code]activity_secret[/code]
+            </description>
+        </method>
+        <method name="close_connection">
+            <description>
+                Disconnect from the current lobby.
+                Should only be called when the user is currently in a lobby.
+            </description>
+        </method>
+        <method name="disconnect_peer">
+            <argument index="0" name="id" type="int">
+            </argument>
+            <description>
+                Removes the user with the id [code]id[/code] from the lobby.
+                Will only be executed when the local user is the owner of the lobby.
+            </description>
+        </method>
+        <method name="get_lobby_id">
+            <returns type="int">
+            </returns>
+            <description>
+                Returns the lobby id of the current lobby.
+                Prints an error if the instance is not connected to a lobby.
+            </description>
+        </method>
+        <method name="get_lobby_secret">
+            <returns type="string">
+            </returns>
+            <description>
+                Returns the lobby secret of the current lobby.
+                Prints an error if the instance is not connected to a lobby.
+            </description>
+        </method>
+        <method name="get_lobby_activity_secret">
+            <returns type="string">
+            </returns>
+            <description>
+                Returns the activity secret of the current lobby.
+                Prints an error if the instance is not connected to a lobby. 
+            </description>
+        </method>
+        <method name="get_current_members" >
+            <returns type="int">
+            </returns>
+            <description>
+                Returns the number of currently connected users.
+                Prints an error if the instance is not connected to a lobby.
+            </description>
+        </method>
+        <method name="get_max_members">
+            <returns type="int">
+            </returns>
+            <description>
+                Returns the capacity of the lobby.
+                Prints an error if the instance is not connected to a lobby.
+            </description>
+        </method>
+        <method name="set_public">
+            <argument index="0" name="public" type="boolean">
+            </argument>
+        </method>
+        <method name="set_size">
+            <argument index="0" name="size" type="int">
+            </argument>
+        </method>
+        <method name="set_metadata">
+            <argument index="0" name="key" type="string">
+            </argument>
+            <argument index="1" name="value" type="string">
+            </argument>
+            <description>
+                Can only be run as the lobby owner.
+                Sets the key/value pair as metadata of the current lobby . 
+                Overwrites the value if the key already exists(?).
+            </description>
+        </method>
+        <method name="get_metadata">
+            <argument index="0" name="key" type="string">
+            </argument>
+            <returns type="string">
+            </returns>
+            <description>
+                Returns the value associated with the key.
+            </description>
+        </method>
+        <method name="get_connected_peers">
+            <returns type="Array">
+            </returns>
+            <description>
+                Returns an array with all connected users
+            </description>
+        </method>
+        <method name="get_user_id_by_peer">
+            <argument index="0" name="peer_id" type="int">
+            </argument> 
+            <description>
+                Returns the user id associated with [code]peer_id[/code].
+            </description>
+        </method>
+        <method name="get_peer_id_by_user">
+            <argument index="0" name="user_id" type="int">
+            </argument> 
+            <description>
+                Returns the peer id associated with [code]user_id[/code].
+            </description>
+        </method>
+    </methods>
+    <signals>
+        <signal name="created_lobby">
+            <description>
+                Emitted when a new lobby has been creates successfully.
+            </description>
+       </signal>
+    </signals>
+</class>


### PR DESCRIPTION
I redid the PR because I messed up the historie of the previous branch.

This pull request adds xml documentation for the project. The xml docs will automatically be included in the engine and can be displayed in the engine (like the normal godot documentation).

This pull request also includes a github action to automatically parse the xml docs and upload them to github pages. This way documentation has to only be written once.